### PR TITLE
adding map_filepath to floorplan schema

### DIFF
--- a/release/1.0.0/models/building/src/openintent-building-floorplan.yaml
+++ b/release/1.0.0/models/building/src/openintent-building-floorplan.yaml
@@ -15,6 +15,9 @@ properties:
     map_uri:
         type: string
         description: url endpoint of where to retrieve the map.
+    map_filepath:
+        type: string
+        description: Relative path to the map image.
     project_name:
         type: string
         description: Name of the project/file

--- a/release/1.0.0/models/oi-wifi.schema.json
+++ b/release/1.0.0/models/oi-wifi.schema.json
@@ -144,6 +144,10 @@
           "type": "string",
           "description": "url endpoint of where to retrieve the map."
         },
+        "map_filepath": {
+          "type": "string",
+          "description": "Relative path to the map image."
+        },
         "project_name": {
           "type": "string",
           "description": "Name of the project/file"

--- a/release/1.0.0/models/src/openintent-wifi.yaml
+++ b/release/1.0.0/models/src/openintent-wifi.yaml
@@ -116,6 +116,9 @@ definitions:
             map_uri:
                 type: string
                 description: url endpoint of where to retrieve the map.
+            map_filepath:
+                type: string
+                description: Relative path to the map image.
             project_name:
                 type: string
                 description: Name of the project/file


### PR DESCRIPTION
Adds map_filepath to floorplan schema.

Use case:
While working with APIs it's more convenient to work with urls/endpoints to download the image, we would like to support exporting/importing a project with a flat file. Working with urls can be difficult in that case, since they usually require authentication and also the traffic can be restricted to unknown locations due to security reasons.

For this reason, we would like to import and export to project in a way, so that it would contain the image files in addition to the OpenIntent definition. This requires that each floor plan would have a reference to the file that has the map image.

This wouldn't replace the map_uri, but just provide an alternative way to reference the images.

Let me know if you want to discuss this further on a call.