### PR TITLE
Change required floorplan_version to openintent_version

### DIFF
--- a/release/2.0.0/models/oi-wifi.schema.json
+++ b/release/2.0.0/models/oi-wifi.schema.json
@@ -8,7 +8,7 @@
     "accesspoints",
     "accesspoint_version",
     "floorplans",
-    "floorplan_version"
+    "openintent_version"
   ],
   "properties": {
     "accesspoints": {


### PR DESCRIPTION
Noticed that the required version property for the file is the floorplan version, probably should be the openintent_version as that one represents the whole file?