### PR TITLE
Allow empty wall segment array

### DIFF
--- a/release/2.0.0/models/src/openintent-wifi.yaml
+++ b/release/2.0.0/models/src/openintent-wifi.yaml
@@ -247,7 +247,6 @@ $defs:
       wall_segments:
         type: array
         description: Segments of wall on floorplan
-        minItems: 1
         items:
           $ref: "#/$defs/wall_segment"
       reference_markers:


### PR DESCRIPTION
The current 2.0.0 wall_segments is a bit weird in that it allows no walls for floorplan only if the wall_segments property is omitted completely from the file. It does not allow empty array as wall_segments property as in 1.0.0 (where the minItems was in invalid place).

So if wall_segments is truly optional, I think the minItems: 1 should be removed.