### PR TITLE
Add vendor-neutral Wi-Fi survey measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ appear in other repositories.
 
 For information on how to contribute to OpenIntent see
 [Contributing](docs/contributing.md)
+
+## Model documentation
+
+* [Vendor-neutral Wi-Fi survey measurements](docs/survey_measurements.md)

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,2 +1,7 @@
+Unreleased: Add vendor-neutral Wi-Fi survey scan events, RSSI observations,
+time-referenced trajectories, collector provenance, and external survey data
+resources. Correct Draft 2020-12 `exclusiveMinimum` usage and the building
+coordinate schema reference.
+
 Oct-19-2023: 1.0.0 - Initial release of OpenIntent Models
 Jan-x-2023: 1.0.1 - Add coordinates to antenna

--- a/docs/survey_measurements.md
+++ b/docs/survey_measurements.md
@@ -1,0 +1,196 @@
+# Vendor-neutral Wi-Fi survey measurements
+
+## Problem
+
+OpenIntent can currently describe a survey path and associate it with a PCAP,
+but it cannot represent the most common survey result directly: a BSSID, RSSI,
+frequency, time, and position. Consequently, two conforming implementations can
+exchange the floorplan and trajectory while still being unable to exchange the
+measurements used to calculate coverage.
+
+A PCAP reference is valuable, but it is not a complete interoperability model:
+
+* many mobile operating systems expose structured scan results without raw
+  802.11 frames;
+* packet capture metadata and RSSI availability differ between adapters and
+  capture formats;
+* a packet capture does not define the indoor position of a received frame;
+* consumers should not have to reproduce a vendor-specific scan-window
+  algorithm to obtain the observations that the producer used; and
+* raw captures can be much larger than the normalized observations required by
+  planning, validation, and visualization tools.
+
+This extension makes normalized observations interoperable while retaining raw
+captures as optional evidence and as a source for future reprocessing.
+
+For example, Android's public
+[`ScanResult`](https://developer.android.com/reference/android/net/wifi/ScanResult)
+model exposes BSSID, RSSI in dBm, frequency, microsecond timestamps, channel
+geometry, security types, information elements, and Wi-Fi 7 MLO identity. A
+portable survey model should be able to preserve those results without requiring
+a packet capture that the platform does not provide.
+
+## Design goals
+
+The model is intended to:
+
+1. represent stop-and-go and continuous passive Wi-Fi surveys;
+2. preserve the measured RSSI for each BSS, including 2.4, 5, and 6 GHz BSSs;
+3. bind every usable observation to a time and an indoor position;
+4. record enough collector provenance to compare measurements responsibly;
+5. work for platform scan APIs, monitor-mode captures, and vendor APIs;
+6. support small inline projects and large externally stored datasets; and
+7. remain backward compatible with existing `survey_path` documents.
+
+The first version deliberately does not standardize spectrum traces, active
+throughput/latency tests, derived heatmaps, interpolation algorithms beyond
+trajectory positioning, or a project archive/container. Those can be added as
+separate profiles without changing the Wi-Fi observation core.
+
+## Logical model
+
+The model has four layers:
+
+```text
+floorplan
+  survey_path (time origin, trajectory, collection provenance)
+    path_point[] (position over time)
+    scan_event[] (one scan result set)
+      wifi_observation[] (one observed BSS)
+    data_resource[] (optional raw or high-volume payloads)
+```
+
+`survey_path` remains the aggregate associated with a floorplan. A
+`scan_event` preserves the collection boundary instead of flattening all BSS
+records into an unordered list. This matters because scanning is not
+instantaneous, scan results can be incomplete, and one scan result set is the
+natural unit returned by many platform APIs.
+
+`wifi_observation` identifies a BSS by BSSID and carries the observed RSSI and
+primary channel frequency. SSID, PHY type, security mode, channel geometry,
+noise, SNR, MLO identity, and raw information elements are optional because
+collector capabilities vary. BSSID is used rather than SSID because multiple
+BSSs can advertise the same SSID and their RSSI values must not be conflated.
+
+## Time representation
+
+New survey data uses an RFC 3339 `survey_path.start_time` as an absolute time
+anchor and non-negative integer microsecond offsets within the path. This avoids
+the precision loss caused by representing a large Unix epoch plus sub-second
+precision as one JSON number. This follows the interoperability guidance in
+[RFC 8259, section 6](https://www.rfc-editor.org/rfc/rfc8259#section-6), which
+notes that commonly used binary64 implementations limit exact numeric
+interchange.
+
+The existing floating-point `path_point.timestamp` remains valid for backward
+compatibility, but it is deprecated for new producers. When both forms are
+present, the integer offset is authoritative.
+
+An observation can have its own `observed_offset_us`. If it is absent, the
+parent `scan_event.started_offset_us` applies. This permits both snapshot-style
+platform results and frame-derived observations with distinct receive times.
+
+## Position representation
+
+A scan event obtains its position in one of two ways:
+
+* it contains `coordinate`; or
+* the path declares `position_interpolation: LINEAR_BY_TIME`, and the position
+  is linearly interpolated between the adjacent time-referenced path points.
+
+With `position_interpolation: NONE`, every scan event must contain `coordinate`.
+With `LINEAR_BY_TIME`, every path point must contain `coordinate` and
+`time_offset_us`. Interpolation must use coordinates with the same unit and
+coordinate system. A consumer must not interpolate across an `END` to `START`
+path discontinuity.
+
+For a stop-and-go survey, producers are encouraged to store the coordinate on
+each scan event even when matching point-path entries are also present. For a
+continuous survey, time-based path interpolation avoids duplicating a coordinate
+for every BSS observation.
+
+## Collector provenance and RSSI
+
+RSSI values are device-dependent. `survey_device` and `survey_wifi_adapter`
+therefore record the hardware, software, driver, firmware, and optional
+calibration information that produced the values.
+
+`scan_event.adapter_identifier` associates a result set with the adapter that
+produced it. It should be present whenever a survey device declares more than
+one adapter. Simultaneous result sets from different adapters remain separate
+scan events even when their time windows overlap.
+
+`wifi_observation.rssi_dbm` is the collector-reported value after applying
+`rssi_calibration_offset_db`, if an offset is declared. For example, a raw value
+of -67 dBm with an offset of +2 dB is stored as -65 dBm. This convention lets a
+consumer compare the normalized values without silently applying an offset a
+second time.
+
+The schema does not impose an artificial RSSI range. Out-of-range values are
+better preserved and flagged by an application than discarded during exchange.
+
+When both `ssid` and `ssid_bytes_base64` are present, the raw byte value is
+authoritative and `ssid` is its display representation.
+
+## Inline observations and external resources
+
+`scan_events` is the vendor-neutral, schema-defined interchange representation.
+It is suitable for mobile surveys and modest datasets and is sufficient to
+reconstruct point RSSI maps without a PCAP.
+
+`data_resources` complements it with document-relative or absolute resources.
+Typical roles include:
+
+* `RAW_80211_CAPTURE` for PCAP or PCAPNG evidence;
+* `WIFI_OBSERVATIONS` for a high-volume structured representation;
+* `TRAJECTORY` for a higher-frequency positioning stream; and
+* future `SPECTRUM` or `ACTIVE_MEASUREMENTS` profiles.
+
+`media_type` describes the physical encoding. A vendor-neutral external
+structured resource that is not defined by the OpenIntent schema also supplies
+`schema_uri`; for example, an implementation can use JSON, CBOR, Apache Arrow,
+or Parquet without making any of those encodings mandatory for all producers.
+`sha256` and `byte_length` allow a portable project archive to verify that the
+resource has not been substituted or truncated.
+
+Raw and normalized forms may coexist. When they do, `scan_events` records the
+measurements selected by the producer for analysis, while the raw resource is
+the lossless source material. Consumers are not expected to regenerate
+`scan_events` byte-for-byte from the raw resource because scan windowing and
+platform filtering can differ.
+
+## Minimum interoperability profile
+
+A producer claiming support for OpenIntent Wi-Fi survey measurements should:
+
+1. provide `survey_path.start_time` and at least one `scan_event`;
+2. give each spatially usable scan event a direct coordinate or a position
+   derivable by `LINEAR_BY_TIME` from time-referenced path points;
+3. provide `bssid`, `rssi_dbm`, and `frequency_mhz` for every Wi-Fi observation;
+4. use canonical lowercase colon-separated MAC addresses;
+5. provide survey device and adapter provenance when it is known; and
+6. use `data_resources.schema_uri` for external normalized records whose schema
+   is not part of OpenIntent.
+
+A raw capture alone remains a valid legacy survey path, but it does not claim
+support for the normalized survey-measurement profile.
+
+## Backward compatibility
+
+All previously defined `survey_path` fields remain accepted. In particular,
+`path_data_uri`, `path_data_type`, the flattened device fields, floating-point
+timestamps, and PCAP-only paths remain valid.
+
+Existing producers need no migration. New producers should use the structured
+`survey_device`, `start_time` plus integer offsets, `scan_events`, and
+`data_resources`. A producer may emit both legacy and new fields during a
+transition; consumers that only understand the earlier model will ignore the
+new properties under the current extensible schema policy.
+
+## Privacy and security
+
+Survey data can reveal precise indoor paths, device identifiers, network names,
+BSSIDs, and raw management frames. Producers should minimize identifiers that
+are not required for the exchange, obtain appropriate consent, and protect the
+OpenIntent document and linked resources as sensitive operational data. A
+resource digest provides integrity, not confidentiality or authenticity.

--- a/release/2.0.0/models/examples/2_1_0_survey_example.json
+++ b/release/2.0.0/models/examples/2_1_0_survey_example.json
@@ -1,0 +1,154 @@
+{
+  "openintent_version": "2.1.0",
+  "floorplans": [
+    {
+      "name": "Warehouse level 1",
+      "project_name": "Warehouse validation survey",
+      "floor_id": "level-1",
+      "dimensions": [
+        {
+          "length": 40,
+          "width": 60,
+          "height": 4,
+          "unit": "meters"
+        }
+      ],
+      "survey_paths": [
+        {
+          "id": "survey-2026-08-15-a",
+          "name": "North aisle continuous survey",
+          "start_time": "2026-08-15T07:30:00.123456Z",
+          "end_time": "2026-08-15T07:30:10.123456Z",
+          "path_type": "CONTINUOUS",
+          "position_interpolation": "LINEAR_BY_TIME",
+          "collection_method": "PLATFORM_SCAN_API",
+          "survey_device": {
+            "identifier": "survey-device-7",
+            "manufacturer": "Example Labs",
+            "model": "Android survey handset",
+            "software_name": "Example Survey",
+            "software_version": "3.2.0",
+            "host_platform": "Android",
+            "host_software_version": "16",
+            "wifi_adapters": [
+              {
+                "identifier": "integrated-wifi",
+                "manufacturer": "Example Radio",
+                "model": "XR-7",
+                "firmware_version": "2026.04",
+                "regulatory_domain": "US",
+                "rssi_calibration_offset_db": 1.5
+              }
+            ]
+          },
+          "path_points": [
+            {
+              "time_offset_us": 0,
+              "path_indicator": "START",
+              "coordinate": {
+                "coordinate_xyz": {
+                  "x": 2,
+                  "y": 3,
+                  "unit": "meters"
+                }
+              }
+            },
+            {
+              "time_offset_us": 5000000,
+              "coordinate": {
+                "coordinate_xyz": {
+                  "x": 12,
+                  "y": 3,
+                  "unit": "meters"
+                }
+              }
+            },
+            {
+              "time_offset_us": 10000000,
+              "path_indicator": "END",
+              "coordinate": {
+                "coordinate_xyz": {
+                  "x": 22,
+                  "y": 3,
+                  "unit": "meters"
+                }
+              }
+            }
+          ],
+          "scan_events": [
+            {
+              "id": "scan-1",
+              "adapter_identifier": "integrated-wifi",
+              "started_offset_us": 2000000,
+              "duration_us": 810000,
+              "result_status": "COMPLETE",
+              "position_accuracy_m": 0.8,
+              "wifi_observations": [
+                {
+                  "observed_offset_us": 2180000,
+                  "bssid": "02:11:22:33:44:50",
+                  "ssid": "Warehouse Wi-Fi",
+                  "rssi_dbm": -54.5,
+                  "frequency_mhz": 5180,
+                  "channel_width": "80_MHz",
+                  "center_frequency_0_mhz": 5210,
+                  "security_modes": [
+                    "WPA2_PERSONAL",
+                    "WPA3_PERSONAL"
+                  ],
+                  "phy_types": [
+                    "IEEE80211_AX"
+                  ]
+                },
+                {
+                  "observed_offset_us": 2410000,
+                  "bssid": "02:11:22:33:44:60",
+                  "ap_mld_mac_address": "02:11:22:33:44:6f",
+                  "mlo_link_id": 0,
+                  "ssid": "Warehouse Wi-Fi",
+                  "rssi_dbm": -61,
+                  "frequency_mhz": 5975,
+                  "channel_width": "20_MHz",
+                  "security_modes": [
+                    "WPA3_PERSONAL"
+                  ],
+                  "phy_types": [
+                    "IEEE80211_BE"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "scan-2",
+              "adapter_identifier": "integrated-wifi",
+              "started_offset_us": 8000000,
+              "duration_us": 790000,
+              "result_status": "COMPLETE",
+              "position_accuracy_m": 0.8,
+              "wifi_observations": [
+                {
+                  "observed_offset_us": 8170000,
+                  "bssid": "02:11:22:33:44:50",
+                  "ssid": "Warehouse Wi-Fi",
+                  "rssi_dbm": -67,
+                  "noise_dbm": -94,
+                  "snr_db": 27,
+                  "frequency_mhz": 5180,
+                  "channel_width": "80_MHz",
+                  "center_frequency_0_mhz": 5210,
+                  "security_modes": [
+                    "WPA2_PERSONAL",
+                    "WPA3_PERSONAL"
+                  ],
+                  "phy_types": [
+                    "IEEE80211_AX"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/release/2.0.0/models/oi-wifi.schema.json
+++ b/release/2.0.0/models/oi-wifi.schema.json
@@ -646,15 +646,11 @@
       "properties": {
         "latitude": {
           "type": "number",
-          "description": "Latitude expressed as ISO 6709 in degrees",
-          "minimum": -90,
-          "maximum": 90
+          "description": "Latitude expressed as ISO 6709 in degrees"
         },
         "longitude": {
           "type": "number",
-          "description": "Longitude expressed as ISO 6709 in degrees",
-          "minimum": -180,
-          "maximum": 180
+          "description": "Longitude expressed as ISO 6709 in degrees"
         },
         "elevation": {
           "type": "number",
@@ -689,20 +685,20 @@
       "properties": {
         "rotation": {
           "type": "number",
-          "minimum": 0,
+          "minimum": -360,
           "maximum": 360,
           "description": "Describes the rotation of the device in degrees where 0 is up on the floorplan orientation. For omnidirectional APs, if looking at the AP on the ceiling, the direction points toward the top of the vendor logo. For directional antennas/APs, the peak beamwidth should point in this direction. AKA yaw.\n"
         },
         "tilt": {
           "type": "number",
-          "minimum": -90,
-          "maximum": 90,
+          "minimum": -360,
+          "maximum": 360,
           "description": "Describes the tilt of the device in degrees. For integrated antenna APs or omnidirectional antenna, 0 describes the default orientation. For directional APs, 0 describes the antenna as pointed horizontal, with positive values tilting up, and negative values pointing down. AKA pitch.\n"
         },
         "roll": {
           "type": "number",
-          "minimum": -180,
-          "maximum": 180,
+          "minimum": -360,
+          "maximum": 360,
           "description": "Describes the rotation of the device in axis of rotation/tilt. 0 describes the devices default orientation. This will normally be zero in most scenarios. Would be used to rotate and antenna from vertical to horizontal polarization. AKA roll.\n"
         }
       }
@@ -932,6 +928,294 @@
         }
       }
     },
+    "survey_wifi_adapter": {
+      "description": "A Wi-Fi adapter used by a survey device. Adapter provenance and RSSI calibration are important when comparing measurements collected by different platforms.\n",
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "Identifier assigned to this adapter within the survey device."
+        },
+        "manufacturer": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "driver_version": {
+          "type": "string"
+        },
+        "firmware_version": {
+          "type": "string"
+        },
+        "regulatory_domain": {
+          "type": "string",
+          "description": "Two-character regulatory domain code when known.",
+          "pattern": "^[A-Z]{2}$"
+        },
+        "rssi_calibration_offset_db": {
+          "type": "number",
+          "description": "Calibration offset in dB that was added to the adapter's reported RSSI values before they were stored in wifi_observation.rssi_dbm.\n"
+        }
+      }
+    },
+    "survey_device": {
+      "description": "Hardware and software provenance for a survey collection.",
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "Identifier assigned to the device by the collecting system."
+        },
+        "manufacturer": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "serial_number": {
+          "type": "string"
+        },
+        "firmware_version": {
+          "type": "string"
+        },
+        "software_name": {
+          "type": "string"
+        },
+        "software_version": {
+          "type": "string"
+        },
+        "host_platform": {
+          "type": "string"
+        },
+        "host_software_version": {
+          "type": "string"
+        },
+        "wifi_adapters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/survey_wifi_adapter"
+          }
+        }
+      }
+    },
+    "survey_data_resource": {
+      "description": "A payload associated with a survey path. Resources allow lossless raw captures and high-volume measurements to remain outside the OpenIntent document while preserving their role, integrity, and schema.\n",
+      "type": "object",
+      "required": [
+        "uri",
+        "role"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Absolute or document-relative URI. Relative references are recommended for portable project archives.\n"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "WIFI_OBSERVATIONS",
+            "RAW_80211_CAPTURE",
+            "TRAJECTORY",
+            "SPECTRUM",
+            "ACTIVE_MEASUREMENTS",
+            "OTHER"
+          ]
+        },
+        "media_type": {
+          "type": "string",
+          "description": "IANA media type of the resource when known.",
+          "example": "application/vnd.tcpdump.pcap"
+        },
+        "schema_uri": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Schema describing a structured external resource. This is required for interoperable vendor-neutral structured data not defined by this OpenIntent schema.\n"
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sha256": {
+          "type": "string",
+          "description": "Lowercase hexadecimal SHA-256 digest of the resource bytes.",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "wifi_security_mode": {
+      "type": "string",
+      "description": "Security mode advertised by a BSS.",
+      "enum": [
+        "OPEN",
+        "OWE",
+        "WEP",
+        "WPA1_PERSONAL",
+        "WPA1_ENTERPRISE",
+        "WPA2_PERSONAL",
+        "WPA2_ENTERPRISE",
+        "WPA3_PERSONAL",
+        "WPA3_ENTERPRISE",
+        "WPA3_ENTERPRISE_192",
+        "DPP",
+        "OTHER"
+      ]
+    },
+    "wifi_phy_type": {
+      "type": "string",
+      "description": "IEEE 802.11 PHY type inferred or reported by the collector.",
+      "enum": [
+        "IEEE80211_A",
+        "IEEE80211_B",
+        "IEEE80211_G",
+        "IEEE80211_N",
+        "IEEE80211_AC",
+        "IEEE80211_AX",
+        "IEEE80211_BE",
+        "OTHER"
+      ]
+    },
+    "wifi_observation": {
+      "description": "One BSS observed during a scan event. RSSI is the value reported by the survey adapter after any declared calibration offset was applied.\n",
+      "type": "object",
+      "required": [
+        "bssid",
+        "rssi_dbm",
+        "frequency_mhz"
+      ],
+      "properties": {
+        "observed_offset_us": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Observation time in integer microseconds after survey_path.start_time. When absent, the parent scan_event time applies.\n"
+        },
+        "bssid": {
+          "type": "string",
+          "description": "Canonical lowercase BSSID.",
+          "pattern": "^([a-f0-9]{2}:){5}[a-f0-9]{2}$"
+        },
+        "ap_mld_mac_address": {
+          "type": "string",
+          "description": "Canonical lowercase AP MLD MAC address for an 802.11be MLO BSS.",
+          "pattern": "^([a-f0-9]{2}:){5}[a-f0-9]{2}$"
+        },
+        "mlo_link_id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 15
+        },
+        "ssid": {
+          "type": "string",
+          "description": "Human-readable SSID when it has a lossless Unicode representation. An empty string represents a hidden SSID.\n"
+        },
+        "ssid_bytes_base64": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "application/octet-stream",
+          "description": "Raw SSID bytes for values that cannot be represented losslessly as Unicode."
+        },
+        "rssi_dbm": {
+          "type": "number",
+          "description": "Received signal strength in dBm."
+        },
+        "noise_dbm": {
+          "type": "number",
+          "description": "Noise floor in dBm when reported by the collector."
+        },
+        "snr_db": {
+          "type": "number",
+          "description": "Signal-to-noise ratio in dB when reported by the collector."
+        },
+        "frequency_mhz": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Primary channel center frequency in MHz."
+        },
+        "channel_width": {
+          "$ref": "#/$defs/channel_width"
+        },
+        "center_frequency_0_mhz": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "center_frequency_1_mhz": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "security_modes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/wifi_security_mode"
+          }
+        },
+        "phy_types": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/wifi_phy_type"
+          }
+        },
+        "information_elements_base64": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "application/octet-stream",
+          "description": "Concatenated raw 802.11 information elements when exposed by the collection platform. This preserves capabilities not normalized by the current schema.\n"
+        }
+      }
+    },
+    "scan_event": {
+      "description": "A scan result set collected at one time. Its position is either given directly by coordinate or derived from the survey path using its time.\n",
+      "type": "object",
+      "required": [
+        "started_offset_us",
+        "wifi_observations"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier unique within the OpenIntent document."
+        },
+        "adapter_identifier": {
+          "type": "string",
+          "description": "Identifier of the survey_device.wifi_adapters entry that produced this scan. It should be present when the device declares more than one adapter.\n"
+        },
+        "started_offset_us": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Scan start in integer microseconds after survey_path.start_time."
+        },
+        "duration_us": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "result_status": {
+          "type": "string",
+          "description": "Collector-reported completeness of the scan result set.",
+          "enum": [
+            "COMPLETE",
+            "PARTIAL",
+            "THROTTLED",
+            "FAILED",
+            "UNKNOWN"
+          ]
+        },
+        "coordinate": {
+          "$ref": "#/$defs/coordinate"
+        },
+        "position_accuracy_m": {
+          "type": "number",
+          "minimum": 0
+        },
+        "wifi_observations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/wifi_observation"
+          }
+        }
+      }
+    },
     "path_point": {
       "description": "A point to be used along a path with reference to the data structure.\n",
       "type": "object",
@@ -941,8 +1225,14 @@
         },
         "timestamp": {
           "type": "number",
-          "description": "Timestamp in Unix epoch format.  example shows nanosecond precision.\n",
+          "deprecated": true,
+          "description": "Timestamp in Unix epoch format. Retained for compatibility; new producers should use survey_path.start_time with time_offset_us to avoid loss of sub-second precision in JSON numbers.\n",
           "example": 1665345722.1234567
+        },
+        "time_offset_us": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Point time in integer microseconds after survey_path.start_time.\n"
         },
         "path_indicator": {
           "type": "string",
@@ -955,18 +1245,106 @@
       }
     },
     "survey_path": {
-      "description": "A series of path_points with a reference to a data uri.  For example, the surveyd data is included in a timestamped PCAP file. You can have multiple survey_path objects pointed at a single PCAP.\n",
+      "description": "A time-referenced survey trajectory and its collected measurements. Measurements may be represented as interoperable inline scan events, external resources such as a PCAP/PCAPNG capture, or both.\n",
       "type": "object",
+      "dependentRequired": {
+        "scan_events": [
+          "start_time"
+        ],
+        "position_interpolation": [
+          "start_time",
+          "path_points"
+        ]
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "position_interpolation": {
+                "const": "LINEAR_BY_TIME"
+              }
+            },
+            "required": [
+              "position_interpolation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "path_points": {
+                "items": {
+                  "required": [
+                    "coordinate",
+                    "time_offset_us"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "position_interpolation": {
+                "const": "NONE"
+              }
+            },
+            "required": [
+              "position_interpolation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "scan_events": {
+                "items": {
+                  "required": [
+                    "coordinate"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier unique within the OpenIntent document."
+        },
+        "name": {
+          "type": "string"
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp used as the origin for integer time offsets."
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time"
+        },
         "path_data_uri": {
           "type": "string",
-          "description": "URI reference to path data. Not all URIs will be resolvable by all systems.",
-          "format": "uri"
+          "description": "Legacy URI reference to path data. New producers should use data_resources, which supports roles, media types, and integrity.\n",
+          "format": "uri-reference"
         },
         "path_data_type": {
           "type": "string",
           "enum": [
             "PCAP",
+            "PCAPNG",
+            "OTHER"
+          ]
+        },
+        "survey_device": {
+          "$ref": "#/$defs/survey_device"
+        },
+        "collection_method": {
+          "type": "string",
+          "description": "Primary method used to collect Wi-Fi observations.",
+          "enum": [
+            "PLATFORM_SCAN_API",
+            "MONITOR_MODE_CAPTURE",
+            "VENDOR_API",
             "OTHER"
           ]
         },
@@ -1003,6 +1381,14 @@
             "CONTINUOUS"
           ]
         },
+        "position_interpolation": {
+          "type": "string",
+          "description": "Method used to derive scan-event coordinates from time-referenced path points. NONE means every scan event requiring a position must include its own coordinate.\n",
+          "enum": [
+            "NONE",
+            "LINEAR_BY_TIME"
+          ]
+        },
         "path_points": {
           "description": "Each path in the path points must have a START and END point. There can be multiple paths within the path_points, but each must contain a START and END point.  These points are ordered from start to end.\n",
           "type": "array",
@@ -1010,6 +1396,20 @@
             "$ref": "#/$defs/path_point"
           },
           "minItems": 2
+        },
+        "scan_events": {
+          "description": "Vendor-neutral Wi-Fi scan results collected on this path.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/scan_event"
+          }
+        },
+        "data_resources": {
+          "description": "External raw or high-volume data associated with this path.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/survey_data_resource"
+          }
         }
       }
     },
@@ -1043,19 +1443,17 @@
         "scale_x": {
           "type": "number",
           "description": "Horizontal scale factor to apply to the floorplan. A value of 1.0 means no scaling. Values greater than 1.0 enlarge, values less than 1.0 shrink. Must be a positive number.\n",
-          "minimum": 0,
-          "exclusiveMinimum": true
+          "exclusiveMinimum": 0
         },
         "scale_y": {
           "type": "number",
           "description": "Vertical scale factor to apply to the floorplan. A value of 1.0 means no scaling. Values greater than 1.0 enlarge, values less than 1.0 shrink. Must be a positive number.\n",
-          "minimum": 0,
-          "exclusiveMinimum": true
+          "exclusiveMinimum": 0
         },
         "rotation": {
           "type": "number",
           "description": "Rotation in degrees to apply to the floorplan around its origin (lower-left corner). Positive values rotate counter-clockwise. This is applied after scaling and before translation.\n",
-          "minimum": 0,
+          "minimum": -360,
           "maximum": 360
         },
         "x_offset": {
@@ -1142,7 +1540,7 @@
           "description": "Physical address information for the building.",
           "$ref": "#/$defs/building_address"
         },
-        "coordinate": {
+        "coordinates": {
           "description": "Geospatial coordinate for the building location. Typically represents the building centroid position.\n",
           "$ref": "#/$defs/coordinate"
         },

--- a/release/2.0.0/models/src/openintent-wifi.yaml
+++ b/release/2.0.0/models/src/openintent-wifi.yaml
@@ -789,6 +789,258 @@ $defs:
           When not present, assumption is the value is false.
         type: boolean
 
+  survey_wifi_adapter:
+    description: >
+      A Wi-Fi adapter used by a survey device. Adapter provenance and RSSI
+      calibration are important when comparing measurements collected by
+      different platforms.
+    type: object
+    properties:
+      identifier:
+        type: string
+        description: Identifier assigned to this adapter within the survey device.
+      manufacturer:
+        type: string
+      model:
+        type: string
+      driver_version:
+        type: string
+      firmware_version:
+        type: string
+      regulatory_domain:
+        type: string
+        description: Two-character regulatory domain code when known.
+        pattern: "^[A-Z]{2}$"
+      rssi_calibration_offset_db:
+        type: number
+        description: >
+          Calibration offset in dB that was added to the adapter's reported
+          RSSI values before they were stored in wifi_observation.rssi_dbm.
+
+  survey_device:
+    description: Hardware and software provenance for a survey collection.
+    type: object
+    properties:
+      identifier:
+        type: string
+        description: Identifier assigned to the device by the collecting system.
+      manufacturer:
+        type: string
+      model:
+        type: string
+      serial_number:
+        type: string
+      firmware_version:
+        type: string
+      software_name:
+        type: string
+      software_version:
+        type: string
+      host_platform:
+        type: string
+      host_software_version:
+        type: string
+      wifi_adapters:
+        type: array
+        items:
+          $ref: "#/$defs/survey_wifi_adapter"
+
+  survey_data_resource:
+    description: >
+      A payload associated with a survey path. Resources allow lossless raw
+      captures and high-volume measurements to remain outside the OpenIntent
+      document while preserving their role, integrity, and schema.
+    type: object
+    required:
+      - uri
+      - role
+    properties:
+      uri:
+        type: string
+        format: uri-reference
+        description: >
+          Absolute or document-relative URI. Relative references are recommended
+          for portable project archives.
+      role:
+        type: string
+        enum:
+          - WIFI_OBSERVATIONS
+          - RAW_80211_CAPTURE
+          - TRAJECTORY
+          - SPECTRUM
+          - ACTIVE_MEASUREMENTS
+          - OTHER
+      media_type:
+        type: string
+        description: IANA media type of the resource when known.
+        example: application/vnd.tcpdump.pcap
+      schema_uri:
+        type: string
+        format: uri-reference
+        description: >
+          Schema describing a structured external resource. This is required
+          for interoperable vendor-neutral structured data not defined by this
+          OpenIntent schema.
+      byte_length:
+        type: integer
+        minimum: 0
+      sha256:
+        type: string
+        description: Lowercase hexadecimal SHA-256 digest of the resource bytes.
+        pattern: "^[a-f0-9]{64}$"
+
+  wifi_security_mode:
+    type: string
+    description: Security mode advertised by a BSS.
+    enum:
+      - OPEN
+      - OWE
+      - WEP
+      - WPA1_PERSONAL
+      - WPA1_ENTERPRISE
+      - WPA2_PERSONAL
+      - WPA2_ENTERPRISE
+      - WPA3_PERSONAL
+      - WPA3_ENTERPRISE
+      - WPA3_ENTERPRISE_192
+      - DPP
+      - OTHER
+
+  wifi_phy_type:
+    type: string
+    description: IEEE 802.11 PHY type inferred or reported by the collector.
+    enum:
+      - IEEE80211_A
+      - IEEE80211_B
+      - IEEE80211_G
+      - IEEE80211_N
+      - IEEE80211_AC
+      - IEEE80211_AX
+      - IEEE80211_BE
+      - OTHER
+
+  wifi_observation:
+    description: >
+      One BSS observed during a scan event. RSSI is the value reported by the
+      survey adapter after any declared calibration offset was applied.
+    type: object
+    required:
+      - bssid
+      - rssi_dbm
+      - frequency_mhz
+    properties:
+      observed_offset_us:
+        type: integer
+        minimum: 0
+        description: >
+          Observation time in integer microseconds after survey_path.start_time.
+          When absent, the parent scan_event time applies.
+      bssid:
+        type: string
+        description: Canonical lowercase BSSID.
+        pattern: "^([a-f0-9]{2}:){5}[a-f0-9]{2}$"
+      ap_mld_mac_address:
+        type: string
+        description: Canonical lowercase AP MLD MAC address for an 802.11be MLO BSS.
+        pattern: "^([a-f0-9]{2}:){5}[a-f0-9]{2}$"
+      mlo_link_id:
+        type: integer
+        minimum: 0
+        maximum: 15
+      ssid:
+        type: string
+        description: >
+          Human-readable SSID when it has a lossless Unicode representation.
+          An empty string represents a hidden SSID.
+      ssid_bytes_base64:
+        type: string
+        contentEncoding: base64
+        contentMediaType: application/octet-stream
+        description: Raw SSID bytes for values that cannot be represented losslessly as Unicode.
+      rssi_dbm:
+        type: number
+        description: Received signal strength in dBm.
+      noise_dbm:
+        type: number
+        description: Noise floor in dBm when reported by the collector.
+      snr_db:
+        type: number
+        description: Signal-to-noise ratio in dB when reported by the collector.
+      frequency_mhz:
+        type: integer
+        minimum: 1
+        description: Primary channel center frequency in MHz.
+      channel_width:
+        $ref: "#/$defs/channel_width"
+      center_frequency_0_mhz:
+        type: integer
+        minimum: 1
+      center_frequency_1_mhz:
+        type: integer
+        minimum: 1
+      security_modes:
+        type: array
+        uniqueItems: true
+        items:
+          $ref: "#/$defs/wifi_security_mode"
+      phy_types:
+        type: array
+        uniqueItems: true
+        items:
+          $ref: "#/$defs/wifi_phy_type"
+      information_elements_base64:
+        type: string
+        contentEncoding: base64
+        contentMediaType: application/octet-stream
+        description: >
+          Concatenated raw 802.11 information elements when exposed by the
+          collection platform. This preserves capabilities not normalized by
+          the current schema.
+
+  scan_event:
+    description: >
+      A scan result set collected at one time. Its position is either given
+      directly by coordinate or derived from the survey path using its time.
+    type: object
+    required:
+      - started_offset_us
+      - wifi_observations
+    properties:
+      id:
+        type: string
+        description: Identifier unique within the OpenIntent document.
+      adapter_identifier:
+        type: string
+        description: >
+          Identifier of the survey_device.wifi_adapters entry that produced
+          this scan. It should be present when the device declares more than
+          one adapter.
+      started_offset_us:
+        type: integer
+        minimum: 0
+        description: Scan start in integer microseconds after survey_path.start_time.
+      duration_us:
+        type: integer
+        minimum: 0
+      result_status:
+        type: string
+        description: Collector-reported completeness of the scan result set.
+        enum:
+          - COMPLETE
+          - PARTIAL
+          - THROTTLED
+          - FAILED
+          - UNKNOWN
+      coordinate:
+        $ref: "#/$defs/coordinate"
+      position_accuracy_m:
+        type: number
+        minimum: 0
+      wifi_observations:
+        type: array
+        items:
+          $ref: "#/$defs/wifi_observation"
+
   path_point:
     description: >
       A point to be used along a path with reference to the data structure.
@@ -798,9 +1050,17 @@ $defs:
         $ref: "#/$defs/coordinate"
       timestamp:
         type: number
+        deprecated: true
         description: >
-          Timestamp in Unix epoch format.  example shows nanosecond precision.
+          Timestamp in Unix epoch format. Retained for compatibility; new
+          producers should use survey_path.start_time with time_offset_us to
+          avoid loss of sub-second precision in JSON numbers.
         example: 1665345722.123456789
+      time_offset_us:
+        type: integer
+        minimum: 0
+        description: >
+          Point time in integer microseconds after survey_path.start_time.
       path_indicator:
         type: string
         enum:
@@ -813,19 +1073,76 @@ $defs:
 
   survey_path:
     description: >
-      A series of path_points with a reference to a data uri.  For example, the
-      surveyd data is included in a timestamped PCAP file. You can have multiple
-      survey_path objects pointed at a single PCAP.
+      A time-referenced survey trajectory and its collected measurements.
+      Measurements may be represented as interoperable inline scan events,
+      external resources such as a PCAP/PCAPNG capture, or both.
     type: object
+    dependentRequired:
+      scan_events:
+        - start_time
+      position_interpolation:
+        - start_time
+        - path_points
+    allOf:
+      - if:
+          properties:
+            position_interpolation:
+              const: LINEAR_BY_TIME
+          required:
+            - position_interpolation
+        then:
+          properties:
+            path_points:
+              items:
+                required:
+                  - coordinate
+                  - time_offset_us
+      - if:
+          properties:
+            position_interpolation:
+              const: NONE
+          required:
+            - position_interpolation
+        then:
+          properties:
+            scan_events:
+              items:
+                required:
+                  - coordinate
     properties:
+      id:
+        type: string
+        description: Identifier unique within the OpenIntent document.
+      name:
+        type: string
+      start_time:
+        type: string
+        format: date-time
+        description: RFC 3339 timestamp used as the origin for integer time offsets.
+      end_time:
+        type: string
+        format: date-time
       path_data_uri:
         type: string
-        description: URI reference to path data. Not all URIs will be resolvable by all systems.
-        format: uri
+        description: >
+          Legacy URI reference to path data. New producers should use
+          data_resources, which supports roles, media types, and integrity.
+        format: uri-reference
       path_data_type:
         type: string
         enum:
           - PCAP
+          - PCAPNG
+          - OTHER
+      survey_device:
+        $ref: "#/$defs/survey_device"
+      collection_method:
+        type: string
+        description: Primary method used to collect Wi-Fi observations.
+        enum:
+          - PLATFORM_SCAN_API
+          - MONITOR_MODE_CAPTURE
+          - VENDOR_API
           - OTHER
       survey_device_model:
         description: path device model
@@ -859,6 +1176,15 @@ $defs:
         enum:
           - POINT
           - CONTINUOUS
+      position_interpolation:
+        type: string
+        description: >
+          Method used to derive scan-event coordinates from time-referenced
+          path points. NONE means every scan event requiring a position must
+          include its own coordinate.
+        enum:
+          - NONE
+          - LINEAR_BY_TIME
       path_points:
         description: >
           Each path in the path points must have a START and END point.
@@ -869,6 +1195,16 @@ $defs:
         items:
           $ref: "#/$defs/path_point"
         minItems: 2
+      scan_events:
+        description: Vendor-neutral Wi-Fi scan results collected on this path.
+        type: array
+        items:
+          $ref: "#/$defs/scan_event"
+      data_resources:
+        description: External raw or high-volume data associated with this path.
+        type: array
+        items:
+          $ref: "#/$defs/survey_data_resource"
 
   offset_value:
     type: object
@@ -902,16 +1238,14 @@ $defs:
           Horizontal scale factor to apply to the floorplan. A value of 1.0 means
           no scaling. Values greater than 1.0 enlarge, values less than 1.0 shrink.
           Must be a positive number.
-        minimum: 0
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
       scale_y:
         type: number
         description: >
           Vertical scale factor to apply to the floorplan. A value of 1.0 means
           no scaling. Values greater than 1.0 enlarge, values less than 1.0 shrink.
           Must be a positive number.
-        minimum: 0
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
       rotation:
         type: number
         description: >
@@ -1016,7 +1350,7 @@ $defs:
         description: >
           Geospatial coordinate for the building location. Typically represents
           the building centroid position.
-        $ref: "#/$defs/coordinates"
+        $ref: "#/$defs/coordinate"
       floors:
         type: array
         description: >
@@ -1025,4 +1359,3 @@ $defs:
         minItems: 1
         items:
           $ref: "#/$defs/building_floor"
-


### PR DESCRIPTION
> **Draft:** This PR proposes a vendor-neutral data model for passive Wi-Fi survey measurements. I am opening it as a draft to collect feedback on the core entities, timing model, positioning rules, and compatibility strategy before marking it ready for review.

## Summary

OpenIntent can currently describe a floorplan, a survey path, and a reference to an external PCAP file. However, it cannot directly represent the normalized measurements used for coverage analysis:

> Which BSSID was observed, at what RSSI and frequency, at what time, and at which position?

This PR extends the existing `survey_path` model with:

- time-referenced Wi-Fi scan events;
- per-BSS observations containing BSSID, RSSI, and frequency;
- optional SSID, channel geometry, security, PHY, information elements, noise/SNR, and Wi-Fi 7 MLO information;
- direct scan coordinates or time-based interpolation along a survey path;
- structured survey-device and Wi-Fi-adapter provenance;
- optional RSSI calibration metadata;
- typed references to external raw or high-volume survey resources;
- a complete continuous-survey example;
- documentation describing the interoperability rules and design rationale.

The proposed model version is `2.1.0`, as the change is additive and does not intentionally break existing OpenIntent documents.

## Motivation

The existing `survey_path` is a useful spatial model, but survey measurements are represented only through:

```text
path_data_uri
path_data_type: PCAP | OTHER
```

A PCAP reference is valuable as raw evidence, but it is not a complete survey interchange contract:

1. Platform collectors can expose structured scan results without providing raw 802.11 frames. Android `ScanResult` is one example.
2. RSSI metadata in a packet capture depends on the adapter, driver, link-layer metadata, and capture format.
3. A packet capture does not define an indoor coordinate or floorplan position.
4. It does not define how frames were grouped into scan result sets.
5. Requiring every consumer to reproduce the producer’s filtering and scan-windowing logic can produce different results from the same project.

The normalized observation model is therefore the interoperability layer. A PCAP or PCAPNG file can still be included as an optional raw resource.

## Logical model

```text
floorplan
  survey_path
    survey_device
      wifi_adapters[]
    path_points[]
    scan_events[]
      wifi_observations[]
    data_resources[]
```

A `scan_event` represents one result set returned or constructed by a collector.

The scan boundary is preserved intentionally because a scan:

- takes a measurable amount of time;
- can be complete, partial, throttled, or failed;
- is normally associated with one Wi-Fi adapter;
- can contain observations with distinct receive timestamps.

Flattening all BSS observations into one unordered list would lose that information and duplicate scan-level position and provenance.

## Minimum observation

Each interoperable `wifi_observation` requires:

```text
bssid
rssi_dbm
frequency_mhz
```

BSSID is required rather than SSID because multiple BSSs can advertise the same SSID and their signal measurements must remain distinguishable.

Collector-dependent values are optional. This allows both platform scan APIs and monitor-mode collectors to use the same logical model without requiring capabilities that a particular platform cannot expose.

## Time representation

The existing path timestamp is a floating-point Unix epoch value whose example implies nanosecond precision.

Large epoch values with long fractional parts do not round-trip reliably through the binary64 number representation commonly used by JSON implementations.

New survey data therefore uses:

```text
survey_path.start_time    RFC 3339 absolute time
*_offset_us               integer microseconds from start_time
```

This provides:

- an absolute time reference;
- exact and compact relative timestamps;
- straightforward ordering and duration calculations;
- compatibility with common platform scan timestamps;
- sufficient resolution for indoor survey positioning.

The existing floating-point `timestamp` remains valid for compatibility but is deprecated for new output.

## Position representation

A scan obtains its position in one of two ways.

### Direct position

With:

```text
position_interpolation: NONE
```

each scan event must contain its own coordinate. This is appropriate for stop-and-go surveys or collectors that already calculate positions.

### Path interpolation

With:

```text
position_interpolation: LINEAR_BY_TIME
```

each path point must contain a coordinate and a microsecond time offset. The scan position is linearly interpolated between adjacent path points.

Consumers must not interpolate across an `END` to `START` path discontinuity.

Linear interpolation is intentionally the first standardized method because it is deterministic and straightforward to implement across vendors. More advanced sensor fusion or path correction can be performed by the producer before export.

## Device provenance and calibration

RSSI values can vary between adapters, antennas, drivers, firmware versions, and collection methods.

The new structured `survey_device` and `survey_wifi_adapter` objects can record:

- manufacturer and model;
- device and adapter identifiers;
- software, driver, and firmware versions;
- host platform;
- regulatory domain;
- RSSI calibration offset.

If a calibration offset is declared, `rssi_dbm` contains the value after that offset has been applied. This prevents consumers from silently applying the same correction twice.

## Inline and external data

Inline `scan_events` provide the schema-defined vendor-neutral representation and are sufficient for small and medium surveys.

`data_resources` allows a survey path to reference:

- raw 802.11 captures;
- high-volume normalized observations;
- higher-frequency trajectory data;
- future spectrum or active-measurement profiles.

This PR intentionally does **not** select a mandatory binary encoding for high-volume observations. A future profile can define that encoding and reference its public schema through `schema_uri`.

The purpose of `data_resources` in this PR is to preserve the architectural separation between:

- normalized survey semantics;
- raw evidence;
- physical storage encoding.

## Backward compatibility

All existing `survey_path` fields remain supported:

| Existing representation | Status |
| --- | --- |
| PCAP-only survey path | Remains valid |
| `path_data_uri` and `path_data_type` | Retained |
| Existing flattened device fields | Retained |
| Floating-point path timestamp | Retained, deprecated for new output |
| Existing OpenIntent 2.0.1 example | Still validates |
| Unknown extension properties | Existing permissive behavior is unchanged |

`path_data_uri` is changed from `uri` to `uri-reference`, allowing portable document-relative paths while continuing to accept absolute URIs.

Existing producers do not need to migrate immediately and may emit legacy and new fields together during a transition.

## Out of scope

This first survey model does not standardize:

- spectrum analyzer traces;
- throughput, latency, or packet-loss tests;
- association and roaming tests;
- derived heatmaps or coverage surfaces;
- RF interpolation algorithms;
- project archive/container packaging;
- a mandatory high-volume binary encoding.

These can be proposed as separate profiles after the passive Wi-Fi observation core is agreed upon.

## Existing schema corrections

Full Draft 2020-12 validation exposed three pre-existing schema issues:

- `exclusiveMinimum` used the boolean syntax from older JSON Schema drafts for `scale_x` and `scale_y`;
- the building coordinate referenced the undefined `#/$defs/coordinates`.

This PR applies the semantics-preserving corrections:

```text
exclusiveMinimum: 0
#/$defs/coordinate
```

These fixes are independent of the survey model and can be split if maintainers prefer.

## Validation

The following checks pass locally using Draft 2020-12 validation with format checking:

- the complete schema passes meta-schema validation;
- all local `$ref` values resolve;
- YAML source and generated JSON are structurally identical;
- the existing 2.0.1 example remains valid;
- the new continuous-survey example is valid;
- a scan with observations but no `start_time` is rejected;
- an observation without RSSI is rejected;
- a non-canonical BSSID is rejected;
- `LINEAR_BY_TIME` rejects path points without time or coordinates;
- `NONE` rejects scan events without coordinates;
- document-relative external resources validate;
- `git diff --check` passes.

## Feedback requested

The most useful early feedback would be on:

1. whether `scan_event` is the correct boundary for a result set;
2. whether BSSID, RSSI, and frequency are the right minimum observation;
3. the RFC 3339 anchor plus integer microsecond offset model;
4. direct positioning versus linear time-based path interpolation;
5. device and adapter provenance requirements;
6. whether `data_resources` is an appropriate extension point for future raw and high-volume profiles.

The goal of this draft is to agree on the smallest useful vendor-neutral passive-survey model before expanding into active measurements, spectrum data, derived products, or binary storage profiles.